### PR TITLE
Add support for 'pull_request_target' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ name: Auto Assign to Project(s)
 on:
   issues:
     types: [opened, labeled]
-  pull_request:
+  pull_request_target:
     types: [opened, labeled]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,6 +98,7 @@ if [ -z "$INITIAL_COLUMN_NAME" ]; then
   # assing the column name by default
   INITIAL_COLUMN_NAME='To do'
   if [ "$GITHUB_EVENT_NAME" == "pull_request" ] || [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
+    echo "changing col name for PR event"
     INITIAL_COLUMN_NAME='In progress'
   fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,8 +97,7 @@ INITIAL_COLUMN_NAME="$INPUT_COLUMN_NAME"
 if [ -z "$INITIAL_COLUMN_NAME" ]; then
   # assing the column name by default
   INITIAL_COLUMN_NAME='To do'
-  if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
-    echo "changing col name for PR event"
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] || [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
     INITIAL_COLUMN_NAME='In progress'
   fi
 fi
@@ -122,7 +121,7 @@ case "$GITHUB_EVENT_NAME" in
      -d "{\"content_type\": \"Issue\", \"content_id\": $ISSUE_ID}" \
      "https://api.github.com/projects/columns/$INITIAL_COLUMN_ID/cards"
     ;;
-  pull_request)
+  pull_request|pull_request_target)
     PULL_REQUEST_ID=$(jq -r '.pull_request.id' < "$GITHUB_EVENT_PATH")
 
     # Add this pull_request to the project column


### PR DESCRIPTION
We are trying to run this workflow in [simple-icons](https://github.com/simple-icons/simple-icons) configuring the token for an organization and we should use the event [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) because we need to give the permission of change project labels to pull requests events opened by external users from their forks, so this pull adds the support for that event.

This could explain #57, but I'm not sure.